### PR TITLE
[fix] No need to decode weibo auth data

### DIFF
--- a/www/wiki/auth/xinlangweibo.page
+++ b/www/wiki/auth/xinlangweibo.page
@@ -26,8 +26,7 @@ local url = accessTokenUrl .. "?client_id=" .. params.client_id .. "&client_secr
 -- Step 1. Exchange authorization code for access token.
 util.GetUrl({url=url, form = params }, resume)
 local err, data = yield()
-data = data.data
-data = commonlib.Json.Decode(data)
+data = commonlib.Json.Decode(data.data) or data.data
 log("=====================xin lang wei bo authenticate======================")
 LOG.std(nil, "error", "keepwork", toJson(data))
 

--- a/www/wiki/js/app/config.js
+++ b/www/wiki/js/app/config.js
@@ -28,6 +28,7 @@
 			"stage.qiankunew.com",
 			"test.qiankunew.com",
 			"wxa.keepwork.tk",
+			"inside.keepwork.tk",
 		],
 		// 预加载模块列表
 		preloadModuleList:[
@@ -100,7 +101,7 @@
 		if (config.isLocal()) {
 			return true;
 		}
-		
+
 		if (window.location.hostname == "wxa.keepwork.tk") {
 			return true;
 		}


### PR DESCRIPTION
微博授权返回的数据不需要decode，微信或者qq的则是需要，需区别开来